### PR TITLE
Param_vector/Param_lemmas: repair `make std` and `make hott` on Rocq dev

### DIFF
--- a/generic/Param_vector.v
+++ b/generic/Param_vector.v
@@ -35,7 +35,7 @@ Definition hd : forall {A : Type} {n : nat}, t A (S n) -> A :=
     return match m with O => Unit | S _ => A end
     with
     | nil => tt
-    | cons _ a _ => a
+    | @cons _ _ a _ => a
     end.
 
 Definition tail : forall {A : Type} {n : nat}, t A (S n) -> t A n :=
@@ -44,7 +44,7 @@ Definition tail : forall {A : Type} {n : nat}, t A (S n) -> t A n :=
     return match m with O => Unit | S k => t A k end
     with
     | nil => tt
-    | cons _ _ v' => v'
+    | @cons _ _ _ v' => v'
     end.
 
 Definition const : forall {A : Type} (a : A) (n : nat), t A n :=
@@ -103,14 +103,14 @@ Definition map :
 Definition t0 {A} (v : t A O) : v = nil := match v in t _ m return
      (match m return t A m -> Type with
        O => fun v => v = nil | S k => fun _ => Unit end) v
-   with nil => 1%path | cons _ _ _ => tt end.
+   with nil => 1%path | @cons _ _ _ _ => tt end.
 
 Definition tE {A n} (v : t A (S n)) : v = cons (hd v) (tail v) :=
  (match v in t _ m return
      (match m return t A m -> Type with
        O => fun _ => Unit | S k => fun v => v = (cons (hd v) (tail v))
      end) v
-   with nil => tt | cons _ a w => 1%path end).
+   with nil => tt | @cons _ _ a w => 1%path end).
 
 Lemma path_prodE  {A B : Type} {x x' : A} {y y' : B} :
   (x, y) = (x', y') -> x = x' /\ y = y'.
@@ -123,7 +123,7 @@ Defined.
 Definition t0P A P (v : t A O) : P nil -> P v := match v in t _ m return
      (match m return t A m -> Type with
        O => fun v => P nil -> P v | S k => fun _ => Unit end) v
-   with nil => idmap | cons _ _ _ => tt end.
+   with nil => idmap | @cons _ _ _ _ => tt end.
 
 Definition tSP A n P : (forall a (v : t A n), P (cons a v)) -> forall v, P v.
 Proof. by move=> Pn v; apply (transport P (tE _)^); apply Pn. Defined.

--- a/hott/Param_lemmas.v
+++ b/hott/Param_lemmas.v
@@ -493,8 +493,8 @@ apply (equiv_compose' equiv_sig_relequiv^-1).
 unshelve eapply equiv_adjointify.
 - move=> [R mR msR]; exists R; exact: umap_equiv_isfun.
 - move=> [R mR msR]; exists R; exact: (umap_equiv_isfun _)^-1%equiv.
-- by move=> [R mR msR]; rewrite !equiv_invK.
-- by move=> [R mR msR]; rewrite !equiv_funK.
+- by move=> [R mR msR]; cbv zeta; rewrite !equiv_invK.
+- by move=> [R mR msR]; cbv zeta; rewrite !equiv_funK.
 Defined.
 
 Definition id_umap {A : Type} : IsUMap (@paths A) :=


### PR DESCRIPTION
`make std` and `make hott` are both red on the Rocq development branch. Two errors, in two files, both in the library rather than in the elpi code:

```
File "./generic/Param_vector.v", line 38, characters 6-16:
Error: The constructor cons (in type t) is expected to be applied to
2 arguments while it is actually applied to 3 arguments.
```

```
File "./Param_lemmas.v", line 496, characters 2-43:
Error: The LHS of equiv_invK
    (_ (_^-1%equiv _))
does not match any subterm of the goal
```

## What the change does

Two files, 7 lines.

- `generic/Param_vector.v` — five `cons` patterns become `@cons` patterns, e.g. `| cons _ a _ => a` → `| @cons _ _ a _ => a`. HoTT's `Vector.t` now elaborates `cons`'s arguments differently in pattern position; writing the pattern with `@` fixes the arity explicitly and is version-independent.
- `hott/Param_lemmas.v` — two `rewrite !equiv_invK` / `rewrite !equiv_funK` calls get a `cbv zeta` first. The goal at those points carries let-bindings that the rewrite's LHS pattern now has to see through; `cbv zeta` clears them and the existing rewrite goes through unchanged.

## Measured

Cold builds of pristine `master` @ `a36529e6`, and of the same tree with only those two files replaced:

| tree | `make std` | `make hott` | `.vo` | `Error` lines |
|---|---|---|---|---|
| `master` @ `a36529e6` | exit 2 | exit 2 | 41 | 2 (the two above) |
| same tree + these two files | **exit 0** | **exit 0** | **62** | **0** |

The patched tree was staged from `git archive` of the pristine commit with exactly those two files copied over; `examples/std/flt3_step.v` was asserted byte-identical to upstream first, and the tree had 0 `.vo` before the build. 62 is the count on disk (25 `hott/`, 24 `std/`, 13 `generic/`) — `generic/` is compiled once under each target, so the log shows more compile actions than there are files.

## `examples/std` is red before and after, and this PR does not fix it

Every file under `examples/std` fails at its import line, on both the pristine and the patched tree:

```
File "./flt3_step.v", line 15, characters 0-39:
Error: Notation "_ ^*" is already defined at level 1 with arguments constr
at level 1 while it is now required to be at level 1 with arguments constr
at next level.
```

Line 15 is `From Trocq Require Import Stdlib Trocq.`; the sibling files get the `_ / _` at level 40 variant. It is a notation-level clash between current mathcomp and Trocq's own `HoTTNotations`, it hits all eight files in that directory, and nothing here addresses it. `make -C examples/hott` is exit 0 throughout.

## Open PRs

Seven are open. I intersected each one's changed-file list against this branch's two files; the intersection is empty in all seven cases, so nothing here needs to be sequenced behind anything. Two are worth naming because they sit next to work this branch deliberately leaves alone:

- rocq-community/trocq#84 ("Examples compatible with upcomming mathcomp 2.6.0", draft) covers `examples/std/{flt3_step,int_to_Zp,square_and_cube_mod7}.v` — exactly the directory whose import error is described above. Nothing here touches those files.
- rocq-community/trocq#90 ("upgrade to elpi 3.5.0") covers `coq-trocq.opam`, `coq-trocq-dev.opam`, `coq-trocq-hott.opam`, the nix config and a workflow. Those are yours to sequence; this PR changes no `.opam` file, no `meta.yml` and no workflow, so it cannot conflict with it.

Separately, and only if it is useful to you: I have an order-independent version of rocq-community/trocq#84's two `flt3_step` goal-selection changes — `try (by …)` in place of choosing `first` or `last`, so it does not depend on which mathcomp is in use and does not need `Unset SsrOldRewriteGoalsOrder.`. I have deliberately left it out of this PR because I could not compile it: `examples/std` never gets past the import error above, so I have no measurement to offer for it, and rocq-community/trocq#84 already owns that file.

## Environment

Rocq `9.4+alpha` (OCaml 4.14.2), coq-hott `dev` @ `b52bd4e9`, mathcomp `dev` @ `d5507bef`.

Two provenance notes, since neither is pristine upstream:

- The prover is built from theorem-labs/rocq@7478cd16, which is `rocq-prover/rocq` master plus 34 commits and minus 17. The fork's substantive addition is a kernel module-subtyping *performance* fix. It cannot turn a compile error into a success, and independently the cone here has no module subtyping to speed up — `Include` and `Module Type` are both 0 across `generic/`, `std/` and `hott/` (23 plain `Module X.` wrappers, 0 functor applications).
- `rocq-elpi` is `theorem-labs/coq-elpi`, branch `dev+fixes`, at `4bc69c6c` when this was built: LPCIC/coq-elpi@270b753e plus two commits adding explicit relevance APIs. It is diverged from `LPCIC/coq-elpi` master, not simply ahead of it. Neither error above is elpi output — both are in hand-written source — but the build around them did run against that elpi, so I cannot claim these numbers reproduce exactly on pristine upstream elpi.

## Not claimed

Compilation of `std` and `hott` only. No test suite was run, `examples/std` does not build for the reason above, and nothing downstream of Trocq was built.
